### PR TITLE
fix: Make the links work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ### Hi there 👋
 
-I'm Peter Keogh, Head of Engineering at [kubicle.com](kubicle.com). I also play bass with [thescratch.ie](thescratch.ie).
+I'm Peter Keogh, Head of Engineering at [https://kubicle.com](kubicle.com). I also play bass with [https://thescratch.ie](thescratch.ie).


### PR DESCRIPTION
Now they just go to: `https://github.com/kubicle.com`